### PR TITLE
ci: add Node.js 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - "node"
+  - "10"
   - "8"


### PR DESCRIPTION
`node` is current stable which is `11` so the new TLS `10` is missing here.